### PR TITLE
Add differentiate payment calculation

### DIFF
--- a/credit_calculator/argument_parser.py
+++ b/credit_calculator/argument_parser.py
@@ -9,7 +9,7 @@ class ArgumentParser:
         self.parser.add_argument(*name_or_flags, **kwargs)
 
     def parse_args(self, args):
-        self.parser.add_argument('--type', choices=['annuity'], help='Annuity')
+        self.parser.add_argument('--type', choices=['annuity', 'diff'], help='Annuity')
         self.parser.add_argument('--principal', type=int, help='Loan principal')
         self.parser.add_argument('--periods', type=int, help='Pay periods, usually the term of the loan in months.')
         self.parser.add_argument('--interest', type=float, help='Interest rate given as a percentage.')

--- a/credit_calculator/calculator.py
+++ b/credit_calculator/calculator.py
@@ -44,13 +44,19 @@ class Calculator(object):
             if value_missing(interest):
                 pass
             else:
-                if value_missing(pay_periods):
-                    return self.annuity_timeframe(principal, payment, interest)
-                else:
-                    if value_missing(principal):
-                        return self.annuity_principal(payment, pay_periods, interest)
+                if calculation_type == 'annuity':
+                    if value_missing(pay_periods):
+                        return self.annuity_timeframe(principal, payment, interest)
                     else:
-                        return self.annuity_payment(principal, pay_periods, interest)
+                        if value_missing(principal):
+                            return self.annuity_principal(payment, pay_periods, interest)
+                        else:
+                            return self.annuity_payment(principal, pay_periods, interest)
+                elif calculation_type == 'diff':
+                    if not value_missing(principal) and not value_missing(pay_periods):
+                        return self.differentiate_payment(principal, pay_periods, interest)
+                    else:
+                        pass
         else:
             pass
 
@@ -138,6 +144,41 @@ class Calculator(object):
             output += f"{months} {month_string} "
 
         output += "to repay this credit!"
+
+        if overpayment > 0:
+            output += f"\nOverpayment = {overpayment}"
+
+        return output
+
+    def differentiate_payment(self, principal: int, timeframe: int, interest_rate: float) -> str:
+        """
+        Calculate all future loan payments.
+
+        In a differentiate payment structure, each pay period has a different payment amount.
+
+        An overpayment amount will also be included if the loan will be overpaid.
+
+        :param principal: Loan principal
+        :param timeframe: Pay periods, usually the amount of time to pay the loan off in months
+        :param interest_rate: Interest rate specified as a percentage, e.g. 12% is 12, 0.9% is 0.9
+        :return: String showing the payments and overpayment, if overpaid
+        """
+        m = 1
+        balance = principal
+        paid = 0
+        output = ""
+
+        while balance > 0:
+            interest = self._interest_rate(interest_rate)
+            formula = (principal / timeframe) + interest * (principal - (principal * (m - 1) / timeframe))
+
+            payment = ceil(formula)
+            output += f"Month {m}: paid out {payment}\n"
+            balance -= payment
+            paid += payment
+            m += 1
+
+        overpayment = paid - principal
 
         if overpayment > 0:
             output += f"\nOverpayment = {overpayment}"

--- a/tests/diff_example_1.txt
+++ b/tests/diff_example_1.txt
@@ -1,0 +1,12 @@
+Month 1: paid out 108334
+Month 2: paid out 107500
+Month 3: paid out 106667
+Month 4: paid out 105834
+Month 5: paid out 105000
+Month 6: paid out 104167
+Month 7: paid out 103334
+Month 8: paid out 102500
+Month 9: paid out 101667
+Month 10: paid out 100834
+
+Overpayment = 45837

--- a/tests/diff_example_2.txt
+++ b/tests/diff_example_2.txt
@@ -1,0 +1,10 @@
+Month 1: paid out 65750
+Month 2: paid out 65344
+Month 3: paid out 64938
+Month 4: paid out 64532
+Month 5: paid out 64125
+Month 6: paid out 63719
+Month 7: paid out 63313
+Month 8: paid out 62907
+
+Overpayment = 14628

--- a/tests/test_differentiate.py
+++ b/tests/test_differentiate.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+
+import pytest
+
+from credit_calculator.calculator import Calculator
+
+
+def text_from_file(file_name: str, stripped: bool = False) -> str:
+    current_directory: Path = Path(__file__).parent
+    path: Path = current_directory / file_name
+
+    if stripped:
+        return path.read_text().strip()
+
+
+@pytest.fixture()
+def calculator():
+    calculator = Calculator()
+
+    yield calculator
+
+
+def test_differentiate_option(calculator):
+    args = [
+        '--type', 'diff'
+    ]
+
+    calculator.calculate(args)
+
+    assert calculator.arguments.type == 'diff'
+
+
+def test_differentiate(calculator):
+    args = [
+        '--type', 'diff',
+        '--principal', '1000000',
+        '--periods', '10',
+        '--interest', '10'
+    ]
+
+    expected_text = text_from_file('diff_example_1.txt', True)
+    actual_text = calculator.calculate(args)
+
+    assert actual_text == expected_text
+
+
+def test_differentiate_again(calculator):
+    args = [
+        '--type', 'diff',
+        '--principal', '500000',
+        '--periods', '8',
+        '--interest', '7.8'
+    ]
+
+    expected_text = text_from_file('diff_example_2.txt', True)
+    actual_text = calculator.calculate(args)
+
+    assert actual_text == expected_text


### PR DESCRIPTION
Sometimes loan payments are variable over the term of the loan.  These are called differentiate payments, and there's a simple formula for calculating them.

If the user elects to calculate differentiate payments, all payments over the term of the loan should be shown along with any overpayment amount.